### PR TITLE
Use explicit classes rather than > selectors

### DIFF
--- a/regulations/static/regulations/css/less/module/drawer-content.less
+++ b/regulations/static/regulations/css/less/module/drawer-content.less
@@ -20,46 +20,38 @@ This contains all of the styles specific to the TOC
       padding-left: 105px;
     }
 
-    .toc-level-1 > a {
+    .toc-entry-at-1, .toc-entry-at-1:hover {
       border-top: 1px solid @light_field;
       .font-bold;
       margin-left: -100px;
       padding: 9px 0 9px 110px;
     }
 
-    .toc-level-1 > ol {
+    .toc-depth-2 {
       border-top: 1px solid @light_field;
       margin-left: -100px;
       padding: 0 0 0 105px;
 
+      .toc-entry-at-2 {
+        padding-top: 5px;
+      }
+      &> li:first-child .toc-entry-at-2 {
+        padding-top: 10px;
+      }
+      &> li:last-child .toc-entry-at-2 {
+        padding-bottom: 10px;
+      }
+    }
+
+    .toc-depth-3 {
       // to account for the last child padding
       // when there's a nested list
-      &>li > ol > li {
-        &>a {
-          padding-top: 5px;
-          padding-bottom: 5px;
-        }
-        &:last-child {
-          &>a {
-            padding-bottom: 10px;
-          }
-        }
+      .toc-entry-at-3 {
+        padding-top: 5px;
+        padding-bottom: 5px;
       }
-
-      &>li {
-        &>a {
-          padding-top: 5px;
-        }
-        &:first-child {
-          &>a {
-            padding-top: 10px;
-          }
-        }
-        &:last-child {
-          &>a {
-            padding-bottom: 10px;
-          }
-        }
+      & > li:last-child .toc-entry-at-3 {
+        padding-bottom: 10px;
       }
     }
   }

--- a/regulations/templates/regulations/toc-preamble.html
+++ b/regulations/templates/regulations/toc-preamble.html
@@ -1,21 +1,23 @@
 {% comment %} 
 Check for preamble_toc first so empty <ol>s aren't drawn when it loops back through.
 {% endcomment %}
+{% with toc_depth=toc_depth|default:1 %}
 {% if preamble_toc %}
-  <ol>
+  <ol class="toc-depth-{{toc_depth}}">
     {% for item in preamble_toc %}
-      <li {% if item.depth == 1 %} class="toc-level-1" {% endif %}>
+      <li>
           <a
               href="{{item.url}}"
               data-section-id="{{item.full_id}}"
-              class="toc-item">
+              class="toc-item toc-entry-at-{{toc_depth}}">
             {{item.title}}
           </a>
 
-        {% with preamble_toc=item.children %}
+        {% with preamble_toc=item.children toc_depth=toc_depth|add:1 %}
           {% include "regulations/toc-preamble.html" %}
         {% endwith %}
       </li>
       {% endfor %}
   </ol>
 {% endif %}
+{% endwith %}


### PR DESCRIPTION
Adds a class to indicate `ol` and `a` depths. This allows the stylesheets to
be flattened a bit without needing all of the `>` selectors.
